### PR TITLE
Include command for tomllib installation

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -35,8 +35,11 @@ Connect via ssh as root to your venus os. If you don't have root access jet, see
 ### Install dependencies:
 Important: You might need to reinstall these dependencies after a venus os update to get the plugin running again as the update seems to overwride everything outside the /data dir)
 
-1. install pip (python package manager): run `opkg update` and `opkg install python3-pip`
-2. install pycryptodomex `pip3 install pycryptodomex`
+1. install pip (python package manager):
+   . ```opkg update && opkg install python3-pip```
+2. install pycryptodomex (+ missing toml lib)
+   - ```opkg install python3-tomllib```
+   - ```pip3 install pycryptodomex```
 
 ### Install plugin:
 


### PR DESCRIPTION
Adds command to fix "No module named 'tomllib'" error when installing dependencies

resolves #20